### PR TITLE
Add hidden exclusive invite landing pages

### DIFF
--- a/app/exclusive-invite/page.tsx
+++ b/app/exclusive-invite/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link'
+import Section from '@/components/Section'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Your tailored invite — Synast Digital',
+  description:
+    'You have been carefully selected to receive this invite because we already see how we can help your business grow for free—reach out and we will show you.',
+  alternates: {
+    canonical: '/exclusive-invite',
+    languages: { 'en-US': '/exclusive-invite', 'ro-RO': '/ro/invitatie-exclusiva' },
+  },
+  robots: { index: false, follow: true },
+}
+
+export default function ExclusiveInvitePage() {
+  return (
+    <main>
+      <Section className="pt-24">
+        <div className="mx-auto max-w-2xl text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-4 py-1 text-sm font-medium text-blue-700">
+            Exclusive invite
+          </span>
+          <h1 className="mt-6 text-4xl font-semibold text-blue-900 md:text-5xl">A tailored partnership preview</h1>
+          <p className="mt-6 text-lg text-ink-600">
+            You&apos;ve been carefully selected to receive this invite because we&apos;ve done our homework on your business and already
+            identified several ways we can help you grow&mdash;for free. All you have to do is contact us and we&apos;ll walk you through the opportunities we&apos;ve uncovered.
+          </p>
+          <p className="mt-6 text-ink-600">
+            Consider this a head start: we come prepared with concrete ideas so our first conversation is about impact, not introductions.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Link href="/contact" className="btn btn-primary">
+              Claim your strategy call
+            </Link>
+            <Link href="/get-to-know-us" className="btn btn-ghost">
+              Learn more about Synast
+            </Link>
+          </div>
+        </div>
+      </Section>
+    </main>
+  )
+}

--- a/app/get-to-know-us/page.tsx
+++ b/app/get-to-know-us/page.tsx
@@ -1,0 +1,57 @@
+import Section from '@/components/Section'
+import TeamVideo from '@/components/TeamVideo'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Get to know us — Synast Digital',
+  description:
+    'Meet the team behind Synast Digital, understand how we work, and see the values that guide every project we take on.',
+  alternates: {
+    canonical: '/get-to-know-us',
+    languages: { 'en-US': '/get-to-know-us', 'ro-RO': '/ro/cunoaste-ne' },
+  },
+}
+
+export default function GetToKnowUsPage() {
+  return (
+    <main>
+      <Section className="pt-24">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-semibold text-blue-900 md:text-5xl">Get to know us</h1>
+          <p className="mt-4 text-lg text-ink-600">
+            Press play to see who we are, how we collaborate, and the kind of impact we create together with our clients.
+          </p>
+        </div>
+
+        <div className="mt-12">
+          <TeamVideo locale="en" />
+        </div>
+
+        <div className="mt-16 grid gap-6 md:grid-cols-3">
+          {[
+            {
+              title: 'Our story',
+              description:
+                'Synast started as a collaboration between strategists, creatives, and engineers who wanted to remove the friction from growing a business.',
+            },
+            {
+              title: 'How we work',
+              description:
+                'From the first discovery call to automation roll-outs, we design every step with clarity, measurable goals, and ongoing optimisation.',
+            },
+            {
+              title: 'Why partners choose us',
+              description:
+                'Transparent communication, measurable results, and a long-term partnership mindset make sure your team feels supported at every step.',
+            },
+          ].map((item) => (
+            <div key={item.title} className="card p-6 text-left">
+              <div className="text-xl font-semibold text-blue-900">{item.title}</div>
+              <p className="mt-3 text-ink-600">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </main>
+  )
+}

--- a/app/ro/cunoaste-ne/page.tsx
+++ b/app/ro/cunoaste-ne/page.tsx
@@ -1,0 +1,57 @@
+import Section from '@/components/Section'
+import TeamVideo from '@/components/TeamVideo'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Cunoaște-ne — Synast Digital',
+  description:
+    'Află cine suntem, cum colaborăm cu partenerii noștri și valorile care ne ghidează fiecare proiect.',
+  alternates: {
+    canonical: '/ro/cunoaste-ne',
+    languages: { 'en-US': '/get-to-know-us', 'ro-RO': '/ro/cunoaste-ne' },
+  },
+}
+
+export default function CunoasteNePage() {
+  return (
+    <main>
+      <Section className="pt-24">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-semibold text-blue-900 md:text-5xl">Cunoaște-ne</h1>
+          <p className="mt-4 text-lg text-ink-600">
+            Dă play pentru a descoperi cine suntem, cum lucrăm și ce rezultate construim împreună cu partenerii noștri.
+          </p>
+        </div>
+
+        <div className="mt-12">
+          <TeamVideo locale="ro" />
+        </div>
+
+        <div className="mt-16 grid gap-6 md:grid-cols-3">
+          {[
+            {
+              title: 'Povestea noastră',
+              description:
+                'Synast a apărut din colaborarea dintre strategi, creativi și ingineri care și-au propus să elimine blocajele din scalarea unei afaceri.',
+            },
+            {
+              title: 'Cum lucrăm',
+              description:
+                'De la prima discuție până la implementarea automatizărilor, planificăm fiecare pas cu obiective clare și îmbunătățiri continue.',
+            },
+            {
+              title: 'De ce ne aleg partenerii',
+              description:
+                'Comunicare transparentă, rezultate măsurabile și parteneriat pe termen lung — echipa ta știe că suntem aproape la fiecare pas.',
+            },
+          ].map((item) => (
+            <div key={item.title} className="card p-6 text-left">
+              <div className="text-xl font-semibold text-blue-900">{item.title}</div>
+              <p className="mt-3 text-ink-600">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+    </main>
+  )
+}

--- a/app/ro/invitatie-exclusiva/page.tsx
+++ b/app/ro/invitatie-exclusiva/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import Section from '@/components/Section'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Invitația ta personalizată — Synast Digital',
+  description:
+    'Ai fost selectat(ă) cu atenție să primești această invitație pentru că am identificat deja cum îți putem crește afacerea, gratuit. Tot ce trebuie să faci este să ne contactezi.',
+  alternates: {
+    canonical: '/ro/invitatie-exclusiva',
+    languages: { 'en-US': '/exclusive-invite', 'ro-RO': '/ro/invitatie-exclusiva' },
+  },
+  robots: { index: false, follow: true },
+}
+
+export default function InvitatieExclusivaPage() {
+  return (
+    <main>
+      <Section className="pt-24">
+        <div className="mx-auto max-w-2xl text-center" lang="ro">
+          <span className="inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-4 py-1 text-sm font-medium text-blue-700">
+            Invitație exclusivă
+          </span>
+          <h1 className="mt-6 text-4xl font-semibold text-blue-900 md:text-5xl">Un preambul la parteneriatul nostru</h1>
+          <p className="mt-6 text-lg text-ink-600">
+            Ai fost selectat(ă) cu atenție să primești această invitație pentru că ne-am făcut temele despre afacerea ta și am identificat deja câteva moduri în care te putem ajuta să crești &mdash; gratuit. Tot ce trebuie să faci este să ne contactezi și îți povestim despre oportunitățile pe care le-am descoperit.
+          </p>
+          <p className="mt-6 text-ink-600">
+            Gândește-te la asta ca la un avans: venim pregătiți cu idei concrete, astfel încât prima discuție este despre impact, nu despre introduceri.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Link href="/ro/contact" className="btn btn-primary">
+              Programează o discuție
+            </Link>
+            <Link href="/ro/cunoaste-ne" className="btn btn-ghost">
+              Află mai multe despre Synast
+            </Link>
+          </div>
+        </div>
+      </Section>
+    </main>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -11,8 +11,10 @@ export default function Footer() {
     company: isRO ? 'Companie' : 'Company',
     contact: 'Contact',
     privacy: isRO ? 'Confidențialitate' : 'Privacy',
+    knowUs: isRO ? 'Cunoaște-ne' : 'Get to know us',
     getInTouch: isRO ? 'Contact' : 'Get in touch',
   }
+  const knowUsHref = isRO ? '/ro/cunoaste-ne/' : '/get-to-know-us/'
 
   return (
     <footer className="section-alt">
@@ -25,6 +27,7 @@ export default function Footer() {
           <div className="font-semibold">{labels.company}</div>
           <Link href={`${base}/contact/`} className="footer-link block">{labels.contact}</Link>
           <Link href={`${base}/privacy/`} className="footer-link block">{labels.privacy}</Link>
+          <Link href={knowUsHref} className="footer-link block">{labels.knowUs}</Link>
         </div>
         <div className="space-y-2">
           <div className="font-semibold">{labels.getInTouch}</div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,8 +9,25 @@ export default function Navbar() {
   const base = isRO ? '/ro' : ''
 
   const labels = isRO
-    ? { services: 'Servicii', process: 'Proces', results: 'Rezultate', about: 'Despre', ctaShort: 'Meeting', ctaLong: 'Programează un meeting' }
-    : { services: 'Services', process: 'Process', results: 'Results', about: 'About', ctaShort: 'Discovery call', ctaLong: 'Book a discovery call' }
+    ? {
+        services: 'Servicii',
+        process: 'Proces',
+        results: 'Rezultate',
+        about: 'Despre',
+        knowUs: 'Cunoaște-ne',
+        ctaShort: 'Meeting',
+        ctaLong: 'Programează un meeting',
+      }
+    : {
+        services: 'Services',
+        process: 'Process',
+        results: 'Results',
+        about: 'About',
+        knowUs: 'Get to know us',
+        ctaShort: 'Discovery call',
+        ctaLong: 'Book a discovery call',
+      }
+  const knowUsHref = isRO ? '/ro/cunoaste-ne/' : '/get-to-know-us/'
 
   return (
     <header className="sticky top-0 z-50 bg-white/80 backdrop-blur border-b border-black/5">
@@ -28,6 +45,9 @@ export default function Navbar() {
           <Link href={`${base}/#process`} className="footer-link">{labels.process}</Link>
           <Link href={`${base}/#results`} className="footer-link">{labels.results}</Link>
           <Link href={`${base}/#about`} className="footer-link">{labels.about}</Link>
+          <Link href={knowUsHref} className="footer-link">
+            {labels.knowUs}
+          </Link>
         </nav>
 
         {/* Right: language + CTA (CTA always visible, smaller on phones) */}

--- a/components/TeamVideo.tsx
+++ b/components/TeamVideo.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+type TeamVideoProps = {
+  locale: 'en' | 'ro'
+  videoId?: string
+}
+
+const FALLBACK_VIDEO_ID = 'VIDEO_ID_HERE'
+
+const copy = {
+  en: {
+    placeholderTitle: 'Your intro video is on the way',
+    placeholderBody:
+      'Upload your presentation to YouTube and set the NEXT_PUBLIC_TEAM_VIDEO_ID environment variable to the video ID (the characters after v= in the URL). The page will update automatically once the ID is in place.',
+    hint: 'The player uses YouTube\'s privacy-enhanced mode so cookies load only after someone presses play.',
+  },
+  ro: {
+    placeholderTitle: 'Videoclipul de prezentare va fi disponibil în curând',
+    placeholderBody:
+      'Încarcă prezentarea pe YouTube și setează variabila de mediu NEXT_PUBLIC_TEAM_VIDEO_ID cu ID-ul videoclipului (caracterele de după v= în link). Pagina se va actualiza automat când ID-ul este completat.',
+    hint: 'Playerul folosește modul YouTube cu confidențialitate sporită, astfel că modulele cookie apar doar după ce utilizatorul apasă play.',
+  },
+} as const satisfies Record<TeamVideoProps['locale'], { placeholderTitle: string; placeholderBody: string; hint: string }>
+
+export default function TeamVideo({ locale, videoId }: TeamVideoProps) {
+  const resolvedVideoId = videoId ?? process.env.NEXT_PUBLIC_TEAM_VIDEO_ID ?? FALLBACK_VIDEO_ID
+  const texts = copy[locale]
+
+  if (resolvedVideoId === FALLBACK_VIDEO_ID) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <div className="rounded-2xl border border-dashed border-blue-700/30 bg-white p-10 text-center shadow-soft">
+          <h2 className="text-2xl font-semibold text-blue-900">{texts.placeholderTitle}</h2>
+          <p className="mt-3 text-ink-600">{texts.placeholderBody}</p>
+        </div>
+        <p className="mt-4 text-center text-sm text-ink-600">{texts.hint}</p>
+      </div>
+    )
+  }
+
+  const embedUrl = `https://www.youtube-nocookie.com/embed/${resolvedVideoId}?rel=0`
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="aspect-video overflow-hidden rounded-2xl shadow-soft">
+        <iframe
+          className="h-full w-full"
+          src={embedUrl}
+          title={locale === 'ro' ? 'Videoclip de prezentare Synast Digital' : 'Synast Digital introduction video'}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      </div>
+      <p className="mt-4 text-center text-sm text-ink-600">{texts.hint}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add an unlisted English exclusive-invite landing page with noindex metadata and tailored outreach messaging
- add the Romanian counterpart mirroring the invite copy and calls to action so invitees can contact the team or explore more

## Testing
- `npm run lint` *(fails: prompts to configure ESLint interactively in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d15f647684832f91d0125e4b65bc94