### PR TITLE
Enhance SEO metadata and structured content

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,64 @@
 import Section from '@/components/Section'
 import ContactForm from '@/components/ContactForm'
+import Script from 'next/script'
+import type { Metadata } from 'next'
 
-export const metadata = { title: 'Contact — Synast Digital' }
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ContactPage',
+  '@id': 'https://www.synastdigital.com/contact',
+  url: 'https://www.synastdigital.com/contact',
+  name: 'Contact Synast Digital',
+  description: 'Book a discovery call with Synast Digital to discuss marketing, branding, and automation projects.',
+  mainEntity: {
+    '@type': 'Organization',
+    name: 'Synast Digital',
+    url: 'https://www.synastdigital.com',
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'customer service',
+        email: 'hello@synastdigital.com',
+        areaServed: ['Romania', 'European Union'],
+        availableLanguage: ['English', 'Romanian'],
+      },
+    ],
+  },
+  potentialAction: {
+    '@type': 'ContactAction',
+    target: 'https://www.synastdigital.com/contact',
+  },
+}
+
+export const metadata: Metadata = {
+  title: 'Contact — Synast Digital',
+  description:
+    'Reach out to Synast Digital for marketing strategy, branding, automation, and digitalisation projects. Book a discovery call or email us directly.',
+  alternates: { canonical: '/contact', languages: { 'en-US': '/contact', 'ro-RO': '/ro/contact' } },
+  openGraph: {
+    title: 'Contact Synast Digital',
+    description:
+      'Let’s discuss your marketing, branding, or automation roadmap. Book a discovery call or email hello@synastdigital.com.',
+    url: 'https://www.synastdigital.com/contact',
+    locale: 'en_US',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact Synast Digital',
+    description:
+      'Book a discovery call to explore marketing, branding, and automation projects with Synast Digital.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+}
 
 export default function ContactEN() {
   return (
@@ -12,9 +69,36 @@ export default function ContactEN() {
           <p className="mt-3 text-ink-600">
             Prefer email? Send us a note at <a className="underline" href="mailto:hello@synastdigital.com">hello@synastdigital.com</a>.
           </p>
+          <div className="mt-6 rounded-2xl border border-blue-100 bg-blue-50/60 p-5 text-sm text-blue-900">
+            <p className="font-semibold">Typical response time: under 2 business days</p>
+            <p className="mt-2">
+              We usually start with a 45-minute discovery call to map your objectives, tech stack, and the quick wins we can unlock together.
+            </p>
+            <dl className="mt-3 space-y-1">
+              <div className="flex gap-2">
+                <dt className="font-semibold">Email:</dt>
+                <dd>
+                  <a className="underline" href="mailto:hello@synastdigital.com">
+                    hello@synastdigital.com
+                  </a>
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-semibold">Languages:</dt>
+                <dd>English · Romanian</dd>
+              </div>
+            </dl>
+          </div>
           <ContactForm locale="en" />
         </div>
       </Section>
+
+      <Script
+        id="contact-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
     </main>
   )
 }

--- a/app/contact/sent/page.tsx
+++ b/app/contact/sent/page.tsx
@@ -1,7 +1,34 @@
 import Section from '@/components/Section'
 import Link from 'next/link'
+import type { Metadata } from 'next'
 
-export const metadata = { title: 'Message sent — Synast Digital' }
+export const metadata: Metadata = {
+  title: 'Message sent — Synast Digital',
+  description: 'Thanks for reaching out to Synast Digital. We will reply within two business days.',
+  alternates: { canonical: '/contact/sent', languages: { 'en-US': '/contact/sent', 'ro-RO': '/ro/contact/sent' } },
+  openGraph: {
+    title: 'Message received — Synast Digital',
+    description: 'We received your message and will reply shortly.',
+    url: 'https://www.synastdigital.com/contact/sent',
+    locale: 'en_US',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Message received — Synast Digital',
+    description: 'We will reply within two business days.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+  robots: { index: false, follow: false },
+}
 
 export default function Sent() {
   return (

--- a/app/exclusive-invite/page.tsx
+++ b/app/exclusive-invite/page.tsx
@@ -11,6 +11,28 @@ export const metadata: Metadata = {
     languages: { 'en-US': '/exclusive-invite', 'ro-RO': '/ro/invitatie-exclusiva' },
   },
   robots: { index: false, follow: true },
+  openGraph: {
+    title: 'Exclusive partnership invite — Synast Digital',
+    description:
+      'A private invitation outlining the growth opportunities Synast Digital has identified for your business.',
+    url: 'https://www.synastdigital.com/exclusive-invite',
+    locale: 'en_US',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Exclusive partnership invite — Synast Digital',
+    description: 'Discover the growth opportunities we researched specifically for your business.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
 }
 
 export default function ExclusiveInvitePage() {

--- a/app/get-to-know-us/page.tsx
+++ b/app/get-to-know-us/page.tsx
@@ -10,6 +10,29 @@ export const metadata: Metadata = {
     canonical: '/get-to-know-us',
     languages: { 'en-US': '/get-to-know-us', 'ro-RO': '/ro/cunoaste-ne' },
   },
+  openGraph: {
+    title: 'Get to know Synast Digital',
+    description:
+      'Discover who we are, how we collaborate, and what it feels like to work with Synast Digital on marketing and automation.',
+    url: 'https://www.synastdigital.com/get-to-know-us',
+    locale: 'en_US',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Get to know Synast Digital',
+    description:
+      'Meet the people shaping Synast Digital, our way of working, and the values that drive every partnership.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
 }
 
 export default function GetToKnowUsPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,8 +9,44 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://www.synastdigital.com'),
   title: { default: 'Synast Digital — Marketing, Strategie & Digitalizare', template: '%s — Synast Digital' },
   description: 'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+  keywords: [
+    'marketing agency romania',
+    'branding strategy',
+    'business process automation',
+    'digital marketing consultancy',
+    'synast digital',
+  ],
   alternates: { canonical: '/', languages: { 'en-US': '/', 'ro-RO': '/ro' } },
   icons: { icon: '/favicon.ico', shortcut: '/favicon.ico', apple: '/apple-touch-icon.png' },
+  authors: [{ name: 'Synast Digital', url: 'https://www.synastdigital.com' }],
+  creator: 'Synast Digital',
+  publisher: 'Synast Digital',
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    alternateLocale: ['ro_RO'],
+    url: 'https://www.synastdigital.com/',
+    siteName: 'Synast Digital',
+    title: 'Synast Digital — Marketing, Strategie & Digitalizare',
+    description:
+      'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Synast Digital — Marketing, Strategie & Digitalizare',
+    description:
+      'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+  robots: { index: true, follow: true },
 }
 
 export const viewport: Viewport = { width: 'device-width', initialScale: 1, viewportFit: 'cover' }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,12 +2,88 @@ import Section from '@/components/Section'
 import Testimonial from '@/components/Testimonial'
 import { Metric } from '@/components/Metrics'
 import Link from 'next/link'
+import Script from 'next/script'
+import type { Metadata } from 'next'
+
+const faqs = [
+  {
+    question: 'What kinds of businesses does Synast Digital partner with?',
+    answer:
+      'We work with funded startups and established SMEs that want clear marketing systems, compelling branding, and automated operations that scale with them.',
+  },
+  {
+    question: 'Do you only build strategy or also help with execution?',
+    answer:
+      'Both. We align with your goals, map quick wins, and then design, implement, and optimise campaigns, websites, and automations so the plan delivers measurable results.',
+  },
+  {
+    question: 'How soon can we see impact after we start?',
+    answer:
+      'You get a roadmap with actions for the first 30, 60, and 90 days. Most partners feel the difference in a few weeks through clearer positioning, faster processes, or early leads.',
+  },
+  {
+    question: 'Can you integrate our existing tools and data sources?',
+    answer:
+      'Yes. We audit your current stack and connect CRM, payments, analytics, and internal dashboards so information flows securely between teams without manual effort.',
+  },
+] satisfies Array<{ question: string; answer: string }>
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'ProfessionalService',
+      '@id': 'https://www.synastdigital.com/#agency',
+      name: 'Synast Digital',
+      url: 'https://www.synastdigital.com/',
+      description:
+        'Synast Digital delivers marketing strategy, branding, and business process automation for founders focused on growth.',
+      image: 'https://www.synastdigital.com/logo.png',
+      areaServed: [
+        { '@type': 'AdministrativeArea', name: 'Romania' },
+        { '@type': 'Country', name: 'European Union' },
+      ],
+      serviceType: ['Marketing strategy', 'Brand identity', 'Business process automation'],
+    },
+    {
+      '@type': 'FAQPage',
+      '@id': 'https://www.synastdigital.com/#faq',
+      mainEntity: faqs.map((faq) => ({
+        '@type': 'Question',
+        name: faq.question,
+        acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+      })),
+    },
+  ],
+}
 
 // app/page.tsx  (EN)
-export const metadata = {
-  title: { absolute: 'Synast Digital — Marketing, Branding & Digitalization', template: '%s — Synast Digital' },
-  description:
-    'You focus on your dream. We handle the rest. Branding, strategy, and business process automation.',
+export const metadata: Metadata = {
+  title: 'Synast Digital — Marketing, Branding & Digitalization',
+  description: 'You focus on your dream. We handle the rest. Branding, strategy, and business process automation.',
+  alternates: { canonical: '/', languages: { 'en-US': '/', 'ro-RO': '/ro' } },
+  openGraph: {
+    title: 'Synast Digital — Marketing, Branding & Digitalization',
+    description:
+      'You focus on your dream. We handle the rest. Branding, strategy, and business process automation.',
+    url: 'https://www.synastdigital.com/',
+    locale: 'en_US',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Synast Digital — Marketing, Branding & Digitalization',
+    description: 'You focus on your dream. We handle the rest. Branding, strategy, and business process automation.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
 }
 
 export default function HomePage() {
@@ -16,18 +92,25 @@ export default function HomePage() {
       {/* Hero */}
       <Section className="pt-24">
         <div className="mx-auto max-w-3xl text-center">
-          <h1 className="mt-4 text-5xl font-semibold tracking-tight text-blue-900">
-            You focus on your dream.
+          <h1 className="text-4xl font-semibold tracking-tight text-blue-900 md:text-5xl">
+            <span className="block">You focus on your dream.</span>
+            <span className="block text-blue-700">We handle the rest.</span>
           </h1>
-          <h1 className="text-5xl font-semibold tracking-tight text-blue-700"></h1>
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-blue-700">
-            We handle the rest.
-          </h1>
-
-          <p className="mt-4 text-lg text-ink-600"></p>
-          <div className="mt-8 flex items-center justify-center gap-4">
-            <Link className="btn btn-primary" href="/contact">Book a discovery call</Link>
-            <a className="btn btn-ghost" href="#process">See how we work</a>
+          <p className="mt-5 text-lg text-ink-600">
+            Synast Digital designs marketing systems, brand identities, and automated workflows so your team can spend less time
+            firefighting and more time building products customers love.
+          </p>
+          <p className="mt-3 text-lg text-ink-600">
+            From positioning and conversion-driven websites to CRM, analytics, and finance integrations, we create the structure
+            that keeps revenue, operations, and customer experience moving in sync.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link className="btn btn-primary" href="/contact">
+              Book a discovery call
+            </Link>
+            <a className="btn btn-ghost" href="#process">
+              See how we work
+            </a>
           </div>
         </div>
       </Section>
@@ -35,44 +118,37 @@ export default function HomePage() {
       {/* Services */}
       <Section id="services">
         {/* Marketing & Brand Growth — grid like Automation */}
-        <h2 className="text-3xl font-semibold text-blue-900 text-center">
-          Marketing & Brand Growth
-        </h2>
+        <h2 className="text-3xl font-semibold text-blue-900 text-center">Marketing & Brand Growth</h2>
         <p className="mt-3 text-ink-600 text-center max-w-2xl mx-auto">
-          We design marketing systems that grow with you. From brand identity to lead generation, we cover it all with clear strategies and measurable results.
+          We design marketing systems that grow with you. From brand identity to lead generation, we cover it all with clear
+          strategies and measurable results.
         </p>
 
         <div className="mt-8 grid gap-6 md:grid-cols-3">
           {[
             {
               title: 'Audit & strategy',
-              desc:
-                'Market analysis, growth potential, and a practical action plan you can keep.',
+              desc: 'Market analysis, growth potential, and a practical action plan you can keep.',
             },
             {
               title: 'Brand identity & guidelines',
-              desc:
-                'Naming, tone, palette, and persona aligned to your vision and the market.',
+              desc: 'Naming, tone, palette, and persona aligned to your vision and the market.',
             },
             {
               title: 'Website that converts',
-              desc:
-                'Design, development, and ongoing maintenance focused on conversion.',
+              desc: 'Design, development, and ongoing maintenance focused on conversion.',
             },
             {
               title: 'Paid campaigns',
-              desc:
-                'End-to-end campaign strategy and management; budgets planned for ROI.',
+              desc: 'End-to-end campaign strategy and management; budgets planned for ROI.',
             },
             {
               title: 'Social media & content',
-              desc:
-                'Planning, creation, posting, and community management across platforms.',
+              desc: 'Planning, creation, posting, and community management across platforms.',
             },
             {
               title: 'Measurement & optimization',
-              desc:
-                'Regular reporting and iterative improvements to maximize results per €.',
+              desc: 'Regular reporting and iterative improvements to maximize results per €.',
             },
           ].map((s) => (
             <div key={s.title} className="card card-hover p-6">
@@ -84,45 +160,37 @@ export default function HomePage() {
 
         {/* Automation & Digitalization — unchanged grid */}
         <div className="mt-16 md:mt-20">
-          <h2 className="text-3xl font-semibold text-blue-900 text-center">
-            Automation & Digitalization
-          </h2>
+          <h2 className="text-3xl font-semibold text-blue-900 text-center">Automation & Digitalization</h2>
           <p className="mt-3 text-ink-600 text-center max-w-2xl mx-auto">
-            We connect your tools, remove repetitive steps, and give you a clear view of what’s
-            happening—so work moves on its own and decisions take minutes, not weeks.
+            We connect your tools, remove repetitive steps, and give you a clear view of what’s happening—so work moves on its own
+            and decisions take minutes, not weeks.
           </p>
 
           <div className="mt-8 grid gap-6 md:grid-cols-3">
             {[
               {
                 title: 'SME systems audit',
-                desc:
-                  'We map your systems and hand you the top 3 quick wins with clear next steps.',
+                desc: 'We map your systems and hand you the top 3 quick wins with clear next steps.',
               },
               {
                 title: 'Process automation',
-                desc:
-                  'We take the busywork out of your tools so the right things happen automatically.',
+                desc: 'We take the busywork out of your tools so the right things happen automatically.',
               },
               {
                 title: 'Operations dashboards',
-                desc:
-                  'Personalized live sales/finance/projects in one place—act fast without chasing sheets.',
+                desc: 'Personalized live sales/finance/projects in one place—act fast without chasing sheets.',
               },
               {
                 title: 'Data pipelines',
-                desc:
-                  'Clean, join, and sync data between apps reliably—no more brittle exports.',
+                desc: 'Clean, join, and sync data between apps reliably—no more brittle exports.',
               },
               {
                 title: 'Training & SOPs',
-                desc:
-                  'Simple SOPs and short videos so the change sticks—your team stays confident.',
+                desc: 'Simple SOPs and short videos so the change sticks—your team stays confident.',
               },
               {
                 title: 'Web integrations',
-                desc:
-                  'Payments, CRM, ERP, email—connected so data flows and nothing falls through the cracks.',
+                desc: 'Payments, CRM, ERP, email—connected so data flows and nothing falls through the cracks.',
               },
             ].map((s) => (
               <div key={s.title} className="card card-hover p-6">
@@ -140,10 +208,13 @@ export default function HomePage() {
         <div className="mt-6 grid gap-6 md:grid-cols-5">
           {[
             ['Discovery meeting', 'We get to know you, your vision and your business.'],
-            ['Audit', 'We make a comprehensive analysis of your business, its growth potential, competitor analysis and action plan.'],
+            [
+              'Audit',
+              'We make a comprehensive analysis of your business, its growth potential, competitor analysis and action plan.',
+            ],
             ['Build', 'Once we agree on the plan, we start the implementation.'],
             ['Measure', '30/60/90-day reports, depending on your business needs, where we measure progress.'],
-            ['Continous improvement', 'We update the strategy based on periodic reports. Our plan grows with you.'],
+            ['Continuous improvement', 'We update the strategy based on periodic reports. Our plan grows with you.'],
           ].map(([t, d]) => (
             <div key={t} className="card p-5">
               <div className="font-semibold">{t}</div>
@@ -156,6 +227,10 @@ export default function HomePage() {
       {/* Results */}
       <Section id="results">
         <h2 className="text-3xl font-semibold text-blue-900">Measurable results</h2>
+        <p className="mt-3 text-ink-600 max-w-2xl">
+          We track every deliverable against agreed KPIs so you can see the impact on sales cycles, conversion rates, and team
+          capacity.
+        </p>
         <div className="mt-6 grid gap-6 md:grid-cols-3">
           <Metric value="−30%" label="admin hours in 6 weeks" />
           <Metric value="2×" label="faster invoice cycle" />
@@ -182,13 +257,38 @@ I recommend her wholeheartedly because she manages to combine creativity with pr
           <div>
             <h2 className="text-3xl font-semibold text-blue-900">About Synast</h2>
             <p className="mt-4 text-ink-600">
-              I’m <strong>Stefania Tudor</strong>, founder of Synast Digital. With a business degree, software engineering background, and experience at multinational consulting companies, my team and I build successful brands and accessible systems for enterprises in Romania. We start with quick wins, tailor it to your business, then bring compounding improvements.
+              I’m <strong>Stefania Tudor</strong>, founder of Synast Digital. With a business degree, software engineering
+              background, and experience at multinational consulting companies, my team and I build successful brands and
+              accessible systems for enterprises in Romania. We start with quick wins, tailor it to your business, then bring
+              compounding improvements.
             </p>
           </div>
           <div className="card p-6">
             <div className="text-lg font-medium">Free 45-minute discovery call</div>
             <p className="mt-2 text-ink-600">We’ll identify 3 high-ROI changes you can make this month.</p>
-            <Link href="/contact" className="mt-4 inline-block btn btn-primary">Book now</Link>
+            <Link href="/contact" className="mt-4 inline-block btn btn-primary">
+              Book now
+            </Link>
+          </div>
+        </div>
+      </Section>
+
+      {/* FAQ */}
+      <Section id="faq">
+        <div className="mx-auto max-w-4xl">
+          <h2 className="text-3xl font-semibold text-blue-900">Frequently asked questions</h2>
+          <p className="mt-3 text-ink-600">
+            Answers to the most common questions founders ask when we start working together.
+          </p>
+          <div className="mt-6 space-y-4">
+            {faqs.map((faq) => (
+              <details key={faq.question} className="group rounded-2xl border border-blue-100 bg-white p-6 shadow-soft">
+                <summary className="cursor-pointer text-left text-lg font-semibold text-blue-900 marker:content-none">
+                  {faq.question}
+                </summary>
+                <p className="mt-3 text-ink-600">{faq.answer}</p>
+              </details>
+            ))}
           </div>
         </div>
       </Section>
@@ -198,9 +298,21 @@ I recommend her wholeheartedly because she manages to combine creativity with pr
         <div className="mx-auto max-w-2xl text-center text-white">
           <h2 className="text-4xl font-semibold">Ready to chase your dream?</h2>
           <p className="mt-3 opacity-90">Let’s build a brand that grows with you.</p>
-          <Link href="/contact" className="mt-8 inline-flex items-center rounded-2xl bg-white/95 px-6 py-3 font-semibold text-blue-900 shadow-soft hover:shadow-lift">Book a free discovery call</Link>
+          <Link
+            href="/contact"
+            className="mt-8 inline-flex items-center rounded-2xl bg-white/95 px-6 py-3 font-semibold text-blue-900 shadow-soft hover:shadow-lift"
+          >
+            Book a free discovery call
+          </Link>
         </div>
       </Section>
+
+      <Script
+        id="home-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
     </main>
   )
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,6 +1,34 @@
 import Section from '@/components/Section'
+import type { Metadata } from 'next'
 
-export const metadata = { title: 'Privacy Policy — Synast Digital' }
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Synast Digital',
+  description:
+    'Learn how Synast Digital collects, processes, and protects personal data for marketing, automation, and contact interactions.',
+  alternates: { canonical: '/privacy', languages: { 'en-US': '/privacy', 'ro-RO': '/ro/privacy' } },
+  openGraph: {
+    title: 'Synast Digital Privacy Policy',
+    description:
+      'Understand Synast Digital’s privacy practices, GDPR commitments, and how to exercise your data rights.',
+    url: 'https://www.synastdigital.com/privacy',
+    locale: 'en_US',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Synast Digital logo',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Synast Digital Privacy Policy',
+    description: 'Read about the data we process, why we process it, and how to contact us for GDPR requests.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+}
 
 export default function Privacy() {
   const updated = new Date().toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })

--- a/app/ro/contact/page.tsx
+++ b/app/ro/contact/page.tsx
@@ -1,7 +1,65 @@
 import Section from '@/components/Section'
 import ContactForm from '@/components/ContactForm'
+import Script from 'next/script'
+import type { Metadata } from 'next'
 
-export const metadata = { title: 'Contact — Synast Digital' }
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'ContactPage',
+  '@id': 'https://www.synastdigital.com/ro/contact',
+  url: 'https://www.synastdigital.com/ro/contact',
+  name: 'Contact Synast Digital',
+  description:
+    'Programează un call cu Synast Digital pentru proiecte de marketing, branding, automatizare și digitalizare.',
+  mainEntity: {
+    '@type': 'Organization',
+    name: 'Synast Digital',
+    url: 'https://www.synastdigital.com/ro',
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'serviciu clienți',
+        email: 'hello@synastdigital.com',
+        areaServed: ['România', 'Uniunea Europeană'],
+        availableLanguage: ['Română', 'Engleză'],
+      },
+    ],
+  },
+  potentialAction: {
+    '@type': 'ContactAction',
+    target: 'https://www.synastdigital.com/ro/contact',
+  },
+}
+
+export const metadata: Metadata = {
+  title: 'Contact — Synast Digital',
+  description:
+    'Scrie-ne la Synast Digital pentru proiecte de marketing, branding, automatizare și digitalizare. Programează un meeting sau trimite-ne un email.',
+  alternates: { canonical: '/ro/contact', languages: { 'en-US': '/contact', 'ro-RO': '/ro/contact' } },
+  openGraph: {
+    title: 'Contact Synast Digital',
+    description:
+      'Hai să discutăm despre strategia ta de marketing, branding sau automatizare. Programează un meeting sau scrie-ne la hello@synastdigital.com.',
+    url: 'https://www.synastdigital.com/ro/contact',
+    locale: 'ro_RO',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact Synast Digital',
+    description:
+      'Programează un meeting pentru a discuta proiectele de marketing și digitalizare cu Synast Digital.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+}
 
 export default function ContactRO() {
   return (
@@ -12,9 +70,36 @@ export default function ContactRO() {
           <p className="mt-3 text-ink-600">
             Sau scrie-ne direct la <a className="underline" href="mailto:hello@synastdigital.com">hello@synastdigital.com</a>.
           </p>
+          <div className="mt-6 rounded-2xl border border-blue-100 bg-blue-50/60 p-5 text-sm text-blue-900">
+            <p className="font-semibold">Timp mediu de răspuns: sub 2 zile lucrătoare</p>
+            <p className="mt-2">
+              Începem de obicei cu un call de 45 de minute în care clarificăm obiectivele, stack-ul tehnic și pașii rapizi pe care îi putem livra împreună.
+            </p>
+            <dl className="mt-3 space-y-1">
+              <div className="flex gap-2">
+                <dt className="font-semibold">Email:</dt>
+                <dd>
+                  <a className="underline" href="mailto:hello@synastdigital.com">
+                    hello@synastdigital.com
+                  </a>
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-semibold">Limbi:</dt>
+                <dd>Română · Engleză</dd>
+              </div>
+            </dl>
+          </div>
           <ContactForm locale="ro" />
         </div>
       </Section>
+
+      <Script
+        id="contact-structured-data-ro"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
     </main>
   )
 }

--- a/app/ro/contact/sent/page.tsx
+++ b/app/ro/contact/sent/page.tsx
@@ -1,6 +1,34 @@
 import Section from '@/components/Section'
 import Link from 'next/link'
-export const metadata = { title: 'Mesaj trimis — Synast Digital' }
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Mesaj trimis — Synast Digital',
+  description: 'Îți mulțumim pentru mesaj. Revenim în cel mult două zile lucrătoare.',
+  alternates: { canonical: '/ro/contact/sent', languages: { 'en-US': '/contact/sent', 'ro-RO': '/ro/contact/sent' } },
+  openGraph: {
+    title: 'Mesaj recepționat — Synast Digital',
+    description: 'Ți-am primit mesajul și revenim în cel mai scurt timp.',
+    url: 'https://www.synastdigital.com/ro/contact/sent',
+    locale: 'ro_RO',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Mesaj recepționat — Synast Digital',
+    description: 'Îți mulțumim pentru mesaj. Revenim în cel mult două zile lucrătoare.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+  robots: { index: false, follow: false },
+}
 export default function SentRO() {
   return (
     <main>

--- a/app/ro/cunoaste-ne/page.tsx
+++ b/app/ro/cunoaste-ne/page.tsx
@@ -10,6 +10,29 @@ export const metadata: Metadata = {
     canonical: '/ro/cunoaste-ne',
     languages: { 'en-US': '/get-to-know-us', 'ro-RO': '/ro/cunoaste-ne' },
   },
+  openGraph: {
+    title: 'Cunoaște echipa Synast Digital',
+    description:
+      'Descoperă cine suntem, cum colaborăm cu partenerii noștri și cum arată o experiență de lucru cu Synast Digital.',
+    url: 'https://www.synastdigital.com/ro/cunoaste-ne',
+    locale: 'ro_RO',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Cunoaște echipa Synast Digital',
+    description:
+      'Află cine suntem, cum lucrăm și valorile care ne ghidează fiecare proiect Synast Digital.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
 }
 
 export default function CunoasteNePage() {

--- a/app/ro/invitatie-exclusiva/page.tsx
+++ b/app/ro/invitatie-exclusiva/page.tsx
@@ -11,6 +11,28 @@ export const metadata: Metadata = {
     languages: { 'en-US': '/exclusive-invite', 'ro-RO': '/ro/invitatie-exclusiva' },
   },
   robots: { index: false, follow: true },
+  openGraph: {
+    title: 'Invitație exclusivă Synast Digital',
+    description:
+      'Descoperă oportunitățile de creștere pe care le-am identificat special pentru afacerea ta.',
+    url: 'https://www.synastdigital.com/ro/invitatie-exclusiva',
+    locale: 'ro_RO',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Invitație exclusivă Synast Digital',
+    description: 'Află ce soluții personalizate am pregătit pentru afacerea ta.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
 }
 
 export default function InvitatieExclusivaPage() {

--- a/app/ro/layout.tsx
+++ b/app/ro/layout.tsx
@@ -8,12 +8,43 @@ export const metadata: Metadata = {
     template: '%s — Synast Digital',
   },
   description: 'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+  keywords: [
+    'agenție marketing românia',
+    'strategie brand',
+    'automatizare procese de business',
+    'digitalizare IMM',
+    'synast digital',
+  ],
   alternates: {
     canonical: '/ro',
     languages: {
       'en': '/',       // English version
       'ro-RO': '/ro',  // Romanian version
     },
+  },
+  openGraph: {
+    locale: 'ro_RO',
+    type: 'website',
+    url: 'https://www.synastdigital.com/ro',
+    siteName: 'Synast Digital',
+    title: 'Synast Digital — Marketing, Branding, Strategie & Digitalizare',
+    description:
+      'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Synast Digital — Marketing, Branding, Strategie & Digitalizare',
+    description:
+      'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+    images: ['https://www.synastdigital.com/logo.png'],
   },
 }
 

--- a/app/ro/page.tsx
+++ b/app/ro/page.tsx
@@ -2,12 +2,89 @@ import Section from '@/components/Section'
 import Testimonial from '@/components/Testimonial'
 import { Metric } from '@/components/Metrics'
 import Link from 'next/link'
+import Script from 'next/script'
+import type { Metadata } from 'next'
+
+const faqs = [
+  {
+    question: 'Cu ce tip de afaceri colaborați?',
+    answer:
+      'Lucrăm cu startup-uri finanțate și IMM-uri consolidate care își doresc sisteme de marketing clare, branding coerent și operațiuni automatizate ce cresc odată cu ele.',
+  },
+  {
+    question: 'Oferiți doar strategie sau și implementare?',
+    answer:
+      'Ambele. Ne aliniem la obiectivele tale, mapăm câștigurile rapide și apoi proiectăm, implementăm și optimizăm campanii, website-uri și automatizări care aduc rezultate măsurabile.',
+  },
+  {
+    question: 'Cât de repede vedem impactul colaborării?',
+    answer:
+      'Primești un plan cu acțiuni pentru primele 30, 60 și 90 de zile. Majoritatea partenerilor observă diferențe în câteva săptămâni prin poziționare mai clară, procese mai rapide sau primele lead-uri.',
+  },
+  {
+    question: 'Puteți integra instrumentele și datele pe care le folosim deja?',
+    answer:
+      'Da. Audităm ecosistemul actual și conectăm CRM, plăți, analitice și tablouri de bord interne astfel încât informațiile să circule sigur între echipe, fără muncă manuală.',
+  },
+] satisfies Array<{ question: string; answer: string }>
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'ProfessionalService',
+      '@id': 'https://www.synastdigital.com/ro/#agency',
+      name: 'Synast Digital',
+      url: 'https://www.synastdigital.com/ro',
+      description:
+        'Synast Digital oferă strategie de marketing, branding și automatizarea proceselor de business pentru fondatori orientați spre creștere.',
+      image: 'https://www.synastdigital.com/logo.png',
+      areaServed: [
+        { '@type': 'AdministrativeArea', name: 'România' },
+        { '@type': 'Country', name: 'Uniunea Europeană' },
+      ],
+      serviceType: ['Strategie de marketing', 'Identitate de brand', 'Automatizare procese'],
+    },
+    {
+      '@type': 'FAQPage',
+      '@id': 'https://www.synastdigital.com/ro/#faq',
+      mainEntity: faqs.map((faq) => ({
+        '@type': 'Question',
+        name: faq.question,
+        acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+      })),
+    },
+  ],
+}
 
 // app/ro/page.tsx  (RO)
-export const metadata = {
-  title: { absolute: 'Synast Digital - Marketing, Branding, Strategie & Digitalizare' },
-  description:
-    'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+export const metadata: Metadata = {
+  title: 'Synast Digital - Marketing, Branding, Strategie & Digitalizare',
+  description: 'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+  alternates: { canonical: '/ro', languages: { 'en-US': '/', 'ro-RO': '/ro' } },
+  openGraph: {
+    title: 'Synast Digital - Marketing, Branding, Strategie & Digitalizare',
+    description:
+      'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+    url: 'https://www.synastdigital.com/ro',
+    locale: 'ro_RO',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Synast Digital - Marketing, Branding, Strategie & Digitalizare',
+    description:
+      'Tu te concentrezi pe visul tău. Noi îți maximizăm veniturile. Branding, strategie și automatizarea proceselor de business.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
 }
 
 export default function HomePage() {
@@ -16,18 +93,25 @@ export default function HomePage() {
       {/* Hero */}
       <Section className="pt-24">
         <div className="mx-auto max-w-3xl text-center">
-          <h1 className="mt-4 text-5xl font-semibold tracking-tight text-blue-900">
-            Tu te concentrezi pe visul tău.
+          <h1 className="text-4xl font-semibold tracking-tight text-blue-900 md:text-5xl">
+            <span className="block">Tu te concentrezi pe visul tău.</span>
+            <span className="block text-blue-700">De restul ne ocupăm noi.</span>
           </h1>
-          <h1 className="text-5xl font-semibold tracking-tight text-blue-700"></h1>
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-blue-700">
-            De restul ne ocupăm noi.
-          </h1>
-
-          <p className="mt-4 text-lg text-ink-600"></p>
-          <div className="mt-8 flex items-center justify-center gap-4">
-            <Link className="btn btn-primary" href="/contact">Programează un meeting</Link>
-            <a className="btn btn-ghost" href="#process">Vezi cum lucrăm</a>
+          <p className="mt-5 text-lg text-ink-600">
+            Synast Digital construiește sisteme de marketing, identități de brand și fluxuri automatizate astfel încât echipa ta
+            să petreacă mai puțin timp cu urgențele și mai mult timp creând experiențe memorabile pentru clienți.
+          </p>
+          <p className="mt-3 text-lg text-ink-600">
+            De la poziționare și website-uri orientate spre conversie la integrarea CRM-ului, analiticelor și a finanțelor,
+            creăm structura care aliniază veniturile, operațiunile și experiența clienților.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link className="btn btn-primary" href="/ro/contact">
+              Programează un meeting
+            </Link>
+            <a className="btn btn-ghost" href="#process">
+              Vezi cum lucrăm
+            </a>
           </div>
         </div>
       </Section>
@@ -35,44 +119,37 @@ export default function HomePage() {
       {/* Services */}
       <Section id="services">
         {/* Marketing & Dezvoltarea Brandului — grid ca la Automatizare */}
-        <h2 className="text-3xl font-semibold text-blue-900 text-center">
-          Marketing & Dezvoltarea Brandului
-        </h2>
+        <h2 className="text-3xl font-semibold text-blue-900 text-center">Marketing & Dezvoltarea Brandului</h2>
         <p className="mt-3 text-ink-600 text-center max-w-2xl mx-auto">
-          Construim sisteme de marketing care cresc odată cu tine. De la identitatea de brand la generarea de lead-uri, acoperim totul cu strategii clare și rezultate măsurabile.
+          Construim sisteme de marketing care cresc odată cu tine. De la identitatea de brand la generarea de lead-uri, acoperim
+          totul cu strategii clare și rezultate măsurabile.
         </p>
 
         <div className="mt-8 grid gap-6 md:grid-cols-3">
           {[
             {
               title: 'Audit & strategie',
-              desc:
-                'Analiză de piață, potențial de creștere și un plan de acțiune practic pe care îl păstrezi.',
+              desc: 'Analiză de piață, potențial de creștere și un plan de acțiune practic pe care îl păstrezi.',
             },
             {
               title: 'Identitate de brand & ghiduri',
-              desc:
-                'Naming, ton, paletă și arhetip aliniate la viziunea ta și la piață.',
+              desc: 'Naming, ton, paletă și arhetip aliniate la viziunea ta și la piață.',
             },
             {
               title: 'Website care convertește',
-              desc:
-                'Design, dezvoltare și mentenanță continuă cu focus pe conversie.',
+              desc: 'Design, dezvoltare și mentenanță continuă cu focus pe conversie.',
             },
             {
               title: 'Campanii plătite',
-              desc:
-                'Strategie și management cap-coadă; bugete planificate pentru ROI.',
+              desc: 'Strategie și management cap-coadă; bugete planificate pentru ROI.',
             },
             {
               title: 'Social media & conținut',
-              desc:
-                'Planificare, creare, postare și community management pe platformele relevante.',
+              desc: 'Planificare, creare, postare și community management pe platformele relevante.',
             },
             {
               title: 'Măsurare & optimizare',
-              desc:
-                'Rapoarte regulate și îmbunătățiri iterative pentru maximum de rezultate per €.',
+              desc: 'Rapoarte regulate și îmbunătățiri iterative pentru maximum de rezultate per €.',
             },
           ].map((s) => (
             <div key={s.title} className="card card-hover p-6">
@@ -84,44 +161,37 @@ export default function HomePage() {
 
         {/* Automatizare & Digitalizare — grid */}
         <div className="mt-16 md:mt-20">
-          <h2 className="text-3xl font-semibold text-blue-900 text-center">
-            Automatizare & Digitalizare
-          </h2>
+          <h2 className="text-3xl font-semibold text-blue-900 text-center">Automatizare & Digitalizare</h2>
           <p className="mt-3 text-ink-600 text-center max-w-2xl mx-auto">
-            Îți conectăm instrumentele, eliminăm pașii repetitivi și îți oferim vizibilitate clară asupra a tot ce se întâmplă — astfel încât munca să meargă de la sine, iar deciziile să dureze minute, nu săptămâni.
+            Îți conectăm instrumentele, eliminăm pașii repetitivi și îți oferim vizibilitate clară asupra a tot ce se întâmplă —
+            astfel încât munca să meargă de la sine, iar deciziile să dureze minute, nu săptămâni.
           </p>
 
           <div className="mt-8 grid gap-6 md:grid-cols-3">
             {[
               {
                 title: 'Audit sisteme pentru IMM-uri',
-                desc:
-                  'Îți mapăm sistemele și îți oferim top 3 câștiguri rapide cu pași următori clari.',
+                desc: 'Îți mapăm sistemele și îți oferim top 3 câștiguri rapide cu pași următori clari.',
               },
               {
                 title: 'Automatizarea proceselor',
-                desc:
-                  'Scoatem munca repetitivă din afacerea ta astfel încât lucrurile să se întâmple automat.',
+                desc: 'Scoatem munca repetitivă din afacerea ta astfel încât lucrurile să se întâmple automat.',
               },
               {
                 title: 'Tablouri de bord operaționale',
-                desc:
-                  'Vânzări/finanțe/proiecte live, într-un singur loc — acționezi rapid fără să urmărești foi de calcul.',
+                desc: 'Vânzări/finanțe/proiecte live, într-un singur loc — acționezi rapid fără să urmărești foi de calcul.',
               },
               {
                 title: 'Fluxuri de date',
-                desc:
-                  'Curățăm, îmbinăm și sincronizăm date între aplicații — fără exporturi fragile.',
+                desc: 'Curățăm, îmbinăm și sincronizăm date între aplicații — fără exporturi fragile.',
               },
               {
                 title: 'Training & SOP-uri',
-                desc:
-                  'SOP-uri simple și ghiduri video scurte ca schimbarea să rămână — echipa rămâne încrezătoare.',
+                desc: 'SOP-uri simple și ghiduri video scurte ca schimbarea să rămână — echipa rămâne încrezătoare.',
               },
               {
                 title: 'Integrări web',
-                desc:
-                  'Plăți, CRM, ERP, email — conectate corect ca datele să circule și nimic să nu se piardă.',
+                desc: 'Plăți, CRM, ERP, email — conectate corect ca datele să circule și nimic să nu se piardă.',
               },
             ].map((s) => (
               <div key={s.title} className="card card-hover p-6">
@@ -155,6 +225,10 @@ export default function HomePage() {
       {/* Results */}
       <Section id="results">
         <h2 className="text-3xl font-semibold text-blue-900">Rezultate măsurabile</h2>
+        <p className="mt-3 text-ink-600 max-w-2xl">
+          Măsurăm fiecare livrabil în raport cu indicatorii agreați ca să vezi impactul în ciclurile de vânzare, ratele de
+          conversie și capacitatea echipei.
+        </p>
         <div className="mt-6 grid gap-6 md:grid-cols-3">
           <Metric value="−30%" label="ore administrative în 6 săptămâni" />
           <Metric value="2×" label="ciclu de facturare mai rapid" />
@@ -166,7 +240,9 @@ export default function HomePage() {
       <Section>
         <h2 className="text-3xl font-semibold text-blue-900">Ce spun clienții</h2>
         <div className="mt-6 grid gap-6 md:grid-cols-2">
-          <Testimonial quote="Colaborarea cu Ștefi pe partea de marketing pentru Foccaceria Zest a fost una dintre cele mai bune decizii pe care le-am luat pentru afacerea mea. Mi-a oferit sprijin pas cu pas, de la structurarea imaginii brandului și până la modul de prezentare online. Mi-a plăcut faptul că a înțeles rapid specificul localului și a venit cu idei creative, adaptate exact la ceea ce îmi doream să transmit clienților. Pe lângă partea de strategie, m-a ajutat și practic, explicându-mi clar ce trebuie făcut și de ce, ceea ce pentru mine a contat enorm. Este o persoană serioasă, implicată și foarte atentă la detalii. Comunicarea cu ea a fost ușoară și plăcută, iar rezultatele s-au văzut imediat în modul în care afacerea mea a început să prindă contur în mediul online. O recomand cu toată inima pentru că reușește să combine creativitatea cu profesionalismul și are talentul de a face lucrurile să pară simple, chiar și atunci când par complicate." author="Georgiana C., Focacceria Zest" />
+          <Testimonial quote="Colaborarea cu Ștefi pe partea de marketing pentru Foccaceria Zest a fost una dintre cele mai bune decizii pe care le-am luat pentru afacerea mea. Mi-a oferit sprijin pas cu pas, de la structurarea imaginii brandului și până la modul de prezentare online. Mi-a plăcut faptul că a înțeles rapid specificul localului și a venit cu idei creative, adaptate exact la ceea ce îmi doream să transmit clienților.
+
+Pe lângă partea de strategie, m-a ajutat și practic, explicându-mi clar ce trebuie făcut și de ce, ceea ce pentru mine a contat enorm. Este o persoană serioasă, implicată și foarte atentă la detalii. Comunicarea cu ea a fost ușoară și plăcută, iar rezultatele s-au văzut imediat în modul în care afacerea mea a început să prindă contur în mediul online. O recomand cu toată inima pentru că reușește să combine creativitatea cu profesionalismul și are talentul de a face lucrurile să pară simple, chiar și atunci când par complicate." author="Georgiana C., Focacceria Zest" />
           <Testimonial quote="Site-ul nostru aduce, în sfârșit, lead-uri. Plan clar, livrare rapidă, rezultate măsurabile." author="Irina G., Practician independent" />
         </div>
       </Section>
@@ -177,13 +253,38 @@ export default function HomePage() {
           <div>
             <h2 className="text-3xl font-semibold text-blue-900">Despre Synast</h2>
             <p className="mt-4 text-ink-600">
-              Sunt <strong>Ștefania Tudor</strong>, fondatoarea Synast Digital. Cu o diplomă în business, background în inginerie software și experiență în companii multinaționale de consultanță, eu și echipa mea construim branduri de succes și sisteme accesibile pentru afacerile din România. Începem cu câștiguri rapide, ne adaptăm afacerii tale și aducem îmbunătățiri ce se cumulează.
+              Sunt <strong>Ștefania Tudor</strong>, fondatoarea Synast Digital. Cu o diplomă în business, background în inginerie
+              software și experiență în companii multinaționale de consultanță, eu și echipa mea construim branduri de succes și
+              sisteme accesibile pentru afacerile din România. Începem cu câștiguri rapide, ne adaptăm afacerii tale și aducem
+              îmbunătățiri ce se cumulează.
             </p>
           </div>
           <div className="card p-6">
             <div className="text-lg font-medium">Sesiune de 45 de minute de cunoaștere</div>
             <p className="mt-2 text-ink-600">Identificăm 3 schimbări de impact pe care le poți face luna aceasta.</p>
-            <Link href="/contact" className="mt-4 inline-block btn btn-primary">Programează acum</Link>
+            <Link href="/ro/contact" className="mt-4 inline-block btn btn-primary">
+              Programează acum
+            </Link>
+          </div>
+        </div>
+      </Section>
+
+      {/* FAQ */}
+      <Section id="faq">
+        <div className="mx-auto max-w-4xl">
+          <h2 className="text-3xl font-semibold text-blue-900">Întrebări frecvente</h2>
+          <p className="mt-3 text-ink-600">
+            Răspunsuri la cele mai des întâlnite întrebări pe care le primim la începutul colaborării.
+          </p>
+          <div className="mt-6 space-y-4">
+            {faqs.map((faq) => (
+              <details key={faq.question} className="group rounded-2xl border border-blue-100 bg-white p-6 shadow-soft">
+                <summary className="cursor-pointer text-left text-lg font-semibold text-blue-900 marker:content-none">
+                  {faq.question}
+                </summary>
+                <p className="mt-3 text-ink-600">{faq.answer}</p>
+              </details>
+            ))}
           </div>
         </div>
       </Section>
@@ -193,11 +294,21 @@ export default function HomePage() {
         <div className="mx-auto max-w-2xl text-center text-white">
           <h2 className="text-4xl font-semibold">Ești gata să-ți urmezi visul?</h2>
           <p className="mt-3 opacity-90">Hai să construim un brand care crește odată cu tine.</p>
-          <Link href="/contact" className="mt-8 inline-flex items-center rounded-2xl bg-white/95 px-6 py-3 font-semibold text-blue-900 shadow-soft hover:shadow-lift">
+          <Link
+            href="/ro/contact"
+            className="mt-8 inline-flex items-center rounded-2xl bg-white/95 px-6 py-3 font-semibold text-blue-900 shadow-soft hover:shadow-lift"
+          >
             Programează o sesiune de cunoaștere
           </Link>
         </div>
       </Section>
+
+      <Script
+        id="home-structured-data-ro"
+        type="application/ld+json"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
     </main>
   )
 }

--- a/app/ro/privacy/page.tsx
+++ b/app/ro/privacy/page.tsx
@@ -1,6 +1,34 @@
 import Section from '@/components/Section'
+import type { Metadata } from 'next'
 
-export const metadata = { title: 'Politica de confidențialitate — Synast Digital' }
+export const metadata: Metadata = {
+  title: 'Politica de confidențialitate — Synast Digital',
+  description:
+    'Află cum Synast Digital colectează, folosește și protejează datele personale și ce drepturi ai conform GDPR.',
+  alternates: { canonical: '/ro/privacy', languages: { 'en-US': '/privacy', 'ro-RO': '/ro/privacy' } },
+  openGraph: {
+    title: 'Politica de confidențialitate Synast Digital',
+    description:
+      'Înțelege practicile noastre de confidențialitate, obligațiile GDPR și modul în care poți face o solicitare legată de date.',
+    url: 'https://www.synastdigital.com/ro/privacy',
+    locale: 'ro_RO',
+    siteName: 'Synast Digital',
+    images: [
+      {
+        url: 'https://www.synastdigital.com/logo.png',
+        width: 512,
+        height: 512,
+        alt: 'Sigla Synast Digital',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Politica de confidențialitate Synast Digital',
+    description: 'Citește ce date prelucrăm, în ce scop și cum ne poți contacta pentru solicitări GDPR.',
+    images: ['https://www.synastdigital.com/logo.png'],
+  },
+}
 
 export default function PrivacyRO() {
   const updated = new Date().toLocaleDateString('ro-RO', { year: 'numeric', month: 'long', day: 'numeric' })

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next'
+
+const baseUrl = 'https://www.synastdigital.com'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/exclusive-invite', '/ro/invitatie-exclusiva', '/contact/sent', '/ro/contact/sent'],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next'
+
+const baseUrl = 'https://www.synastdigital.com'
+
+const routes: Array<{
+  path: string
+  changeFrequency: NonNullable<MetadataRoute.Sitemap[0]['changeFrequency']>
+  priority: number
+}> = [
+  { path: '/', changeFrequency: 'weekly', priority: 1 },
+  { path: '/get-to-know-us', changeFrequency: 'monthly', priority: 0.7 },
+  { path: '/contact', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/privacy', changeFrequency: 'yearly', priority: 0.4 },
+  { path: '/ro', changeFrequency: 'weekly', priority: 1 },
+  { path: '/ro/cunoaste-ne', changeFrequency: 'monthly', priority: 0.7 },
+  { path: '/ro/contact', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/ro/privacy', changeFrequency: 'yearly', priority: 0.4 },
+]
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date()
+  return routes.map((route) => ({
+    url: `${baseUrl}${route.path}`,
+    lastModified,
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }))
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,6 +12,7 @@ export default function Footer() {
     contact: 'Contact',
     privacy: isRO ? 'Confidențialitate' : 'Privacy',
     knowUs: isRO ? 'Cunoaște-ne' : 'Get to know us',
+    faq: isRO ? 'Întrebări frecvente' : 'FAQ',
     getInTouch: isRO ? 'Contact' : 'Get in touch',
   }
   const knowUsHref = isRO ? '/ro/cunoaste-ne/' : '/get-to-know-us/'
@@ -28,6 +29,7 @@ export default function Footer() {
           <Link href={`${base}/contact/`} className="footer-link block">{labels.contact}</Link>
           <Link href={`${base}/privacy/`} className="footer-link block">{labels.privacy}</Link>
           <Link href={knowUsHref} className="footer-link block">{labels.knowUs}</Link>
+          <Link href={`${base}/#faq`} className="footer-link block">{labels.faq}</Link>
         </div>
         <div className="space-y-2">
           <div className="font-semibold">{labels.getInTouch}</div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -15,6 +15,7 @@ export default function Navbar() {
         results: 'Rezultate',
         about: 'Despre',
         knowUs: 'Cunoaște-ne',
+        faq: 'Întrebări',
         ctaShort: 'Meeting',
         ctaLong: 'Programează un meeting',
       }
@@ -24,6 +25,7 @@ export default function Navbar() {
         results: 'Results',
         about: 'About',
         knowUs: 'Get to know us',
+        faq: 'FAQ',
         ctaShort: 'Discovery call',
         ctaLong: 'Book a discovery call',
       }
@@ -45,6 +47,7 @@ export default function Navbar() {
           <Link href={`${base}/#process`} className="footer-link">{labels.process}</Link>
           <Link href={`${base}/#results`} className="footer-link">{labels.results}</Link>
           <Link href={`${base}/#about`} className="footer-link">{labels.about}</Link>
+          <Link href={`${base}/#faq`} className="footer-link">{labels.faq}</Link>
           <Link href={knowUsHref} className="footer-link">
             {labels.knowUs}
           </Link>
@@ -55,18 +58,13 @@ export default function Navbar() {
           <Link href={isRO ? '/' : '/ro/'} className="footer-link text-sm md:text-base">
             {isRO ? 'EN' : 'RO'}
           </Link>
-		  <Link
-  href={`${base}/contact/`}
-  className="btn inline-flex rounded-xl px-3 py-2 text-sm whitespace-nowrap shadow-soft
-             md:rounded-2xl md:px-5 md:py-3 md:text-base
-             !bg-[#F6C000] hover:!bg-[#E0AE00]
-             !text-white hover:!text-white
-             focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#E0AE00]"
->
-  <span className="md:hidden">{labels.ctaShort}</span>
-  <span className="hidden md:inline">{labels.ctaLong}</span>
-</Link>
-
+          <Link
+            href={`${base}/contact/`}
+            className="btn inline-flex rounded-xl px-3 py-2 text-sm whitespace-nowrap shadow-soft md:rounded-2xl md:px-5 md:py-3 md:text-base !bg-[#F6C000] hover:!bg-[#E0AE00] !text-white hover:!text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#E0AE00]"
+          >
+            <span className="md:hidden">{labels.ctaShort}</span>
+            <span className="hidden md:inline">{labels.ctaLong}</span>
+          </Link>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- expand the site-wide metadata defaults and publish robots.txt/sitemap routes for better crawl control
- enrich both the English and Romanian home pages with SEO-focused hero copy, FAQs, and JSON-LD structured data
- add comprehensive per-page metadata and contact structured data while linking the new FAQ section from the navigation and footer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2f8bb4860832fb905f84bf819dc24